### PR TITLE
Correct minor typo and fix the getzola.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Desarrollo
 
-Se necesica [Zola](getzola.org). Teniendo eso iniciar el sitio en modo
+Se necesita [Zola](https://getzola.org). Teniendo eso iniciar el sitio en modo
 desarrollo es sencillo:
 
     zola serve


### PR DESCRIPTION
Correct a typo ('necesica' to 'necesita') and fix the link to getzola.org.